### PR TITLE
SVG/PNG export

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,15 @@ The following options are available:
   "options": {
     "fontSize": 9, // font size for labels and amino acids (if available)
     "fontFamily": "Helvetica",
-    "labelFontColor": "#222222",
-    "labelBackgroundColor": "#e9e9e9",
+    "labelFontColor": "#333333",
+    "labelBackgroundPlusStrandColor": "#ffffff",
+    "labelBackgroundMinusStrandColor": "#ffffff",
+    "labelStrokePlusStrandColor": "#999999",
+    "labelStrokeMinusStrandColor": "#999999",
     "plusStrandColor": "#bdbfff", // color of coding parts of the exon on the plus strand
     "minusStrandColor": "#fabec2", // color of coding parts of the exon on the negative strand
     "utrColor": "#C0EAAF", // color of untranslated regions of the exons
+    "backgroundColor": "#ffffff", // color of track background
     "transcriptHeight": 12, // height of the transcripts
     "transcriptSpacing": 2, // space in between the transcripts
     "name": "Gene transcripts",
@@ -103,7 +107,7 @@ Whenever there is a statement such as the following, assuming `higlass-transcrip
 import { TranscriptsTrack } from 'higlass-transcripts';
 ```
 
-Then TranscriptsTrack would automatically be imported from the `./es` directory (set via package.json's `"module"` value). 
+Then `TranscriptsTrack` would automatically be imported from the `./es` directory (set via package.json's `"module"` value). 
 
 ## Support
 

--- a/scripts/aggregate_transcripts.py
+++ b/scripts/aggregate_transcripts.py
@@ -10,20 +10,7 @@ import slugid
 import math
 import collections as col
 import json
-
-filepath = "extracted_transcripts_20200814.txt"
-#filepath = "gene_table_v2_transcripts_names_new.txt"
-output_file = "transcripts_20200814.beddb"
-#output_file = "transcripts_20200723_3.beddb"
-importance_column = 5
-has_header = False
-chromosome = None
-max_transcripts_per_tile = 5
-tile_size = 1024
-delimiter = '\t'
-chromsizes_filename = 'hg38_full.txt'
-offset = 0
-
+import click
 
 def load_chromsizes(chromsizes_filename, assembly=None):
     """
@@ -473,17 +460,38 @@ def aggregate_bedfile(
     conn.commit()
     return True
 
+@click.command(context_settings=dict(
+    allow_extra_args=False,
+))
+@click.help_option('--help', '-h')
+@click.option('-i', '--input-filename', required=True, type=str)
+@click.option('-c', '--chromsizes-filename', required=True, type=str)
+@click.option('-o', '--output-filename', required=True, type=str)
+def main(**kwargs):
+    filepath = kwargs["input_filename"]
+    #filepath = "gene_table_v2_transcripts_names_new.txt"
+    output_file = kwargs["output_filename"]
+    #output_file = "transcripts_20200723_3.beddb"
+    importance_column = 5
+    has_header = False
+    chromosome = None
+    max_transcripts_per_tile = 5
+    tile_size = 1024
+    delimiter = '\t'
+    chromsizes_filename = kwargs["chromsizes_filename"]
+    offset = 0
+    aggregate_bedfile(
+        filepath,
+        output_file,
+        importance_column,
+        has_header,
+        chromosome,
+        max_transcripts_per_tile,
+        tile_size,
+        delimiter,
+        chromsizes_filename,
+        offset,
+    )
 
-
-aggregate_bedfile(
-    filepath,
-    output_file,
-    importance_column,
-    has_header,
-    chromosome,
-    max_transcripts_per_tile,
-    tile_size,
-    delimiter,
-    chromsizes_filename,
-    offset,
-)
+if __name__ == '__main__':
+    main()

--- a/scripts/commands.txt
+++ b/scripts/commands.txt
@@ -1,11 +1,15 @@
 # Extract transcripts data from GTF file
 
-python extract_transcript_data.py
+python extract_transcript_data.py --input-filename annotations.gtf --chromsizes-filename chromSizes.txt --output-filename transcripts.txt
 
-# Aggregate with clods
+# Aggregate with aggregate_transcripts.py
 
-clodius aggregate bedfile --max-per-tile 20 --importance-column 5 --chromsizes-filename chromInfo_hg38.txt --output-file transcripts_20200722.db --delimiter $'\t' gene_table_v2_transcripts_names_new.txt
+python aggregate_transcripts.py --input-filename transcripts.txt --chromsizes-filename chromSizes.txt --output-filename transcripts.beddb
+
+# Aggregate with clodius
+
+clodius aggregate bedfile --max-per-tile 20 --importance-column 5 --chromsizes-filename chromSizes.txt --output-file transcripts.beddb --delimiter $'\t' transcripts.txt
 
 # Ingest to server
 
-python manage.py ingest_tileset --filename data/transcripts_20200722.db --filetype beddb --datatype gene-annotation --uid transcripts_20200722
+python manage.py ingest_tileset --filename transcripts.beddb --filetype beddb --datatype gene-annotation --uid transcripts_abcd1234

--- a/scripts/extract_transcript_data.py
+++ b/scripts/extract_transcript_data.py
@@ -2,157 +2,168 @@ from gtfparse import read_gtf
 import gzip
 import csv
 import random
+import click
 
-# Input/Output file names (need to be in same folder)
-# Gencode file
-gencode_file = 'gencode.v29.annotation.gtf'
-# Chromosome file
-chr_file = 'hg38_full.txt'
-# Output file
-output_file = 'extracted_transcripts_20200814.txt'
-
-
-df_orig = read_gtf(gencode_file)
-#df = df_orig.head(20000)
-df = df_orig
-total_entries = len(df)
-print("Length of dataframe: ", total_entries)
-
-data = {}
-
-# We use random ints for the importance column. Could be replaces with publication counts
-# pub_count = {}
-# with gzip.open('gencode.v29.metadata.Pubmed_id.gz', 'rb') as f:
-#     for item in f:
-#         line = item.decode().strip().split('\t')
-#         if line[0] not in pub_count:
-#             pub_count[line[0]] = 0
-#         pub_count[line[0]] = pub_count[line[0]] + 1
-
-with open(chr_file, 'r') as opf:
-    chrsizes = opf.readlines()
-
-chrms = [i.split('\t')[0] for i in chrsizes]
-
-for i, v in df.iterrows():
-    if i % 5000 == 0:
-        print("Progress: ", str(i),"/", str(total_entries))
-    if v['feature'] == 'transcript' or v['feature'] == 'exon' or v['feature'] == 'CDS' or v['feature'] == 'start_codon' or v['feature'] == 'stop_codon':
-        if v['gene_id'] not in data:
-            data[v['gene_id']] = {}
-
-        if v['transcript_id'] not in data[v['gene_id']]:
-            data[v['gene_id']][v['transcript_id']] = {
-                'chr': '', 
-                'start': '', 
-                'end': '', 
-                'transcript_name': '', 
-                'citationCount': 1,  
-                'strand': '', 
-                'transcript_id': v['transcript_id'], 
-                'gene_id': v['gene_id'], 
-                'gene_type': '', 
-                'CDSStarts': '', 
-                'CDSEnds': '', 
-                'ExonStarts': '', 
-                'ExonEnds': '',
-                'StartCodonStart': '.',
-                'StopCodonStart': '.'}
-
-        if v['feature'] == 'transcript':
-            data[v['gene_id']][v['transcript_id']]['chr'] = v['seqname']
-            data[v['gene_id']][v['transcript_id']]['start'] = v['start']
-            data[v['gene_id']][v['transcript_id']]['end'] = v['end']
-            data[v['gene_id']][v['transcript_id']]['transcript_name'] = v['transcript_name']
-            data[v['gene_id']][v['transcript_id']]['strand'] = v['strand']
-            data[v['gene_id']][v['transcript_id']]['gene_type'] = v['gene_type']
-
-        if v['feature'] == 'exon':
-            data[v['gene_id']][v['transcript_id']]['ExonStarts'] += str(v['start']) + ','
-            data[v['gene_id']][v['transcript_id']]['ExonEnds'] += str(v['end']) + ','
-
-        if v['feature'] == 'CDS':
-            data[v['gene_id']][v['transcript_id']]['CDSStarts'] += str(v['start']) + ','
-            data[v['gene_id']][v['transcript_id']]['CDSEnds'] += str(v['end']) + ','
-        
-        if v['feature'] == 'start_codon':
-            data[v['gene_id']][v['transcript_id']]['StartCodonStart'] = str(v['start']) 
-
-        if v['feature'] == 'stop_codon':
-            data[v['gene_id']][v['transcript_id']]['StopCodonStart'] = str(v['start']) 
+@click.command(context_settings=dict(
+    allow_extra_args=False,
+))
+@click.help_option('--help', '-h')
+@click.option('-i', '--input-filename', required=True, type=str)
+@click.option('-c', '--chromsizes-filename', required=True, type=str)
+@click.option('-o', '--output-filename', required=True, type=str)
+def main(**kwargs):
+    # Input/Output file names (need to be in same folder)
+    # Gencode file
+    gencode_file = kwargs["input_filename"]
+    # Chromosome file
+    chr_file = kwargs["chromsizes_filename"]
+    # Output file
+    output_file = kwargs["output_filename"]
+    
+    df_orig = read_gtf(gencode_file)
+    #df = df_orig.head(20000)
+    df = df_orig
+    total_entries = len(df)
+    print("Length of dataframe: ", total_entries)
+    
+    data = {}
+    
+    # We use random ints for the importance column. Could be replaces with publication counts
+    # pub_count = {}
+    # with gzip.open('gencode.v29.metadata.Pubmed_id.gz', 'rb') as f:
+    #     for item in f:
+    #         line = item.decode().strip().split('\t')
+    #         if line[0] not in pub_count:
+    #             pub_count[line[0]] = 0
+    #         pub_count[line[0]] = pub_count[line[0]] + 1
+    
+    with open(chr_file, 'r') as opf:
+        chrsizes = opf.readlines()
+    
+    chrms = [i.split('\t')[0] for i in chrsizes]
+    
+    for i, v in df.iterrows():
+        if i % 5000 == 0:
+            print("Progress: ", str(i),"/", str(total_entries))
+        if v['feature'] == 'transcript' or v['feature'] == 'exon' or v['feature'] == 'CDS' or v['feature'] == 'start_codon' or v['feature'] == 'stop_codon':
+            if v['gene_id'] not in data:
+                data[v['gene_id']] = {}
+    
+            if v['transcript_id'] not in data[v['gene_id']]:
+                data[v['gene_id']][v['transcript_id']] = {
+                    'chr': '', 
+                    'start': '', 
+                    'end': '', 
+                    'transcript_name': '', 
+                    'citationCount': 1,  
+                    'strand': '', 
+                    'transcript_id': v['transcript_id'], 
+                    'gene_id': v['gene_id'], 
+                    'gene_type': '', 
+                    'CDSStarts': '', 
+                    'CDSEnds': '', 
+                    'ExonStarts': '', 
+                    'ExonEnds': '',
+                    'StartCodonStart': '.',
+                    'StopCodonStart': '.'}
+    
+            if v['feature'] == 'transcript':
+                data[v['gene_id']][v['transcript_id']]['chr'] = v['seqname']
+                data[v['gene_id']][v['transcript_id']]['start'] = v['start']
+                data[v['gene_id']][v['transcript_id']]['end'] = v['end']
+                data[v['gene_id']][v['transcript_id']]['transcript_name'] = v['transcript_name']
+                data[v['gene_id']][v['transcript_id']]['strand'] = v['strand']
+                data[v['gene_id']][v['transcript_id']]['gene_type'] = v['gene_type']
+    
+            if v['feature'] == 'exon':
+                data[v['gene_id']][v['transcript_id']]['ExonStarts'] += str(v['start']) + ','
+                data[v['gene_id']][v['transcript_id']]['ExonEnds'] += str(v['end']) + ','
+    
+            if v['feature'] == 'CDS':
+                data[v['gene_id']][v['transcript_id']]['CDSStarts'] += str(v['start']) + ','
+                data[v['gene_id']][v['transcript_id']]['CDSEnds'] += str(v['end']) + ','
             
-data = dict(sorted(data.items()))
-
-for gene_id, transcripts in data.items():
-    # Each transcript of the same gene gets the same importance value (could be changed)
-    importance = random.randint(1,100)
-
-    for transcript_id, info in transcripts.items():
-        if info['gene_type'] == 'protein_coding' or info['gene_type'] == 'miRNA':
-            if info['chr'] in chrms:
-                exons_start = info['CDSStarts'].split(',')[:-1]
-                exons_start_formated = [int(i) for i in exons_start]
-                cds_start = min(exons_start_formated) if len(exons_start_formated)>0 else "." 
-                exons_end = info['CDSEnds'].split(',')[:-1]
-                exons_end_formated = [int(i) for i in exons_end]
-                cds_end = max(exons_end_formated) if len(exons_end_formated)>0 else "."
-
-                if info['gene_type'] == 'miRNA':
-                    info['StartCodonStart'] = '.'
-                    info['StopCodonStart'] = '.'
+            if v['feature'] == 'start_codon':
+                data[v['gene_id']][v['transcript_id']]['StartCodonStart'] = str(v['start']) 
+    
+            if v['feature'] == 'stop_codon':
+                data[v['gene_id']][v['transcript_id']]['StopCodonStart'] = str(v['start']) 
                 
-                if info['StartCodonStart'] != '.' and info['StopCodonStart'] == '.':
-                    info['StopCodonStart'] = cds_end
+    data = dict(sorted(data.items()))
+    
+    for gene_id, transcripts in data.items():
+        # Each transcript of the same gene gets the same importance value (could be changed)
+        importance = random.randint(1,100)
+    
+        for transcript_id, info in transcripts.items():
+            if info['gene_type'] == 'protein_coding' or info['gene_type'] == 'miRNA':
+                if info['chr'] in chrms:
+                    exons_start = info['CDSStarts'].split(',')[:-1]
+                    exons_start_formated = [int(i) for i in exons_start]
+                    cds_start = min(exons_start_formated) if len(exons_start_formated)>0 else "." 
+                    exons_end = info['CDSEnds'].split(',')[:-1]
+                    exons_end_formated = [int(i) for i in exons_end]
+                    cds_end = max(exons_end_formated) if len(exons_end_formated)>0 else "."
+    
+                    if info['gene_type'] == 'miRNA':
+                        info['StartCodonStart'] = '.'
+                        info['StopCodonStart'] = '.'
+                    
+                    if info['StartCodonStart'] != '.' and info['StopCodonStart'] == '.':
+                        info['StopCodonStart'] = cds_end
+    
+                    # if it is protein coding but we don't know the start codon, display it as non coding
+                    if info['StartCodonStart'] == '.' and info['StopCodonStart'] != '.':
+                        info['StartCodonStart'] = '.'
+                        info['StopCodonStart'] = '.'
+    
+                    exons_start = info['ExonStarts'].split(',')[:-1]
+                    exons_start_formated = sorted([int(i) for i in exons_start])
+                    info['ExonStarts'] = ",".join([str(e) for e in exons_start_formated])
+    
+                    exons_end = info['ExonEnds'].split(',')[:-1]
+                    exons_end_formated = sorted([int(i) for i in exons_end])
+                    info['ExonEnds'] = ",".join([str(e) for e in exons_end_formated])
+    
+                    info['citationCount'] = importance
+                    # if transcript_id in pub_count:
+                    #     info['citationCount'] = pub_count[transcript_id]
+    
+    # remove unnecessary fields
+    data_clean = {}
+    output = []
+    for gene_id, transcripts in data.items():
+        for transcript_id, info in transcripts.items():
+            
+            if info['gene_type'] == 'protein_coding' or info['gene_type'] == 'miRNA':
+                #print("TRANSCRIPT_ITEM",transcript_id, info)
+                if info['chr'] in chrms:
+                    if info['gene_id'] not in data_clean:
+                        data_clean[info['gene_id']] = {}
+    
+                    if info['transcript_id'] not in data_clean[info['gene_id']]:
+                        data_clean[info['gene_id']][info['transcript_id']] = {
+                            'chr': info['chr'], 
+                            'start': info['start'], 
+                            'end': info['end'], 
+                            'transcript_name': info['transcript_name'], 
+                            'citationCount': info['citationCount'],  
+                            'strand': info['strand'], 
+                            'gene_id': info['gene_id'], 
+                            'transcript_id': info['transcript_id'], 
+                            'gene_type': info['gene_type'], 
+                            'ExonStarts': info['ExonStarts'], 
+                            'ExonEnds': info['ExonEnds'],
+                            'StartCodonStart': info['StartCodonStart'],
+                            'StopCodonStart': info['StopCodonStart']}
+    
+                        output.append(data_clean[info['gene_id']][info['transcript_id']])
+    
+    headers = output[0].keys()
+    with open(output_file, 'w') as opf:
+        myWriter = csv.DictWriter(opf, delimiter='\t', fieldnames=headers)
+        for row in output:
+            myWriter.writerow(row)
 
-                # if it is protein coding but we don't know the start codon, display it as non coding
-                if info['StartCodonStart'] == '.' and info['StopCodonStart'] != '.':
-                    info['StartCodonStart'] = '.'
-                    info['StopCodonStart'] = '.'
-
-                exons_start = info['ExonStarts'].split(',')[:-1]
-                exons_start_formated = sorted([int(i) for i in exons_start])
-                info['ExonStarts'] = ",".join([str(e) for e in exons_start_formated])
-
-                exons_end = info['ExonEnds'].split(',')[:-1]
-                exons_end_formated = sorted([int(i) for i in exons_end])
-                info['ExonEnds'] = ",".join([str(e) for e in exons_end_formated])
-
-                info['citationCount'] = importance
-                # if transcript_id in pub_count:
-                #     info['citationCount'] = pub_count[transcript_id]
-
-# remove unnecessary fields
-data_clean = {}
-output = []
-for gene_id, transcripts in data.items():
-    for transcript_id, info in transcripts.items():
-        
-        if info['gene_type'] == 'protein_coding' or info['gene_type'] == 'miRNA':
-            #print("TRANSCRIPT_ITEM",transcript_id, info)
-            if info['chr'] in chrms:
-                if info['gene_id'] not in data_clean:
-                    data_clean[info['gene_id']] = {}
-
-                if info['transcript_id'] not in data_clean[info['gene_id']]:
-                    data_clean[info['gene_id']][info['transcript_id']] = {
-                        'chr': info['chr'], 
-                        'start': info['start'], 
-                        'end': info['end'], 
-                        'transcript_name': info['transcript_name'], 
-                        'citationCount': info['citationCount'],  
-                        'strand': info['strand'], 
-                        'gene_id': info['gene_id'], 
-                        'transcript_id': info['transcript_id'], 
-                        'gene_type': info['gene_type'], 
-                        'ExonStarts': info['ExonStarts'], 
-                        'ExonEnds': info['ExonEnds'],
-                        'StartCodonStart': info['StartCodonStart'],
-                        'StopCodonStart': info['StopCodonStart']}
-
-                    output.append(data_clean[info['gene_id']][info['transcript_id']])
-
-headers = output[0].keys()
-with open(output_file, 'w') as opf:
-    myWriter = csv.DictWriter(opf, delimiter='\t', fieldnames=headers)
-    for row in output:
-        myWriter.writerow(row)
+if __name__ == '__main__':
+    main()

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import register from 'higlass-register';
 
-import { TranscriptsTrack} from './scripts';
+import { TranscriptsTrack } from './scripts';
 
 register({
   name: 'TranscriptsTrack',


### PR DESCRIPTION
I ran into some cosmetic issues exporting SVG/PNG from a `horizontal-transcripts` track, where the appearance of the background and label in the SVG output did not match the rendered HiGlass track. 

For example, here is a view that shows the transcripts track in the browser (roughly):

![epilogos hg19 15 S1 all chr3_69756986-chr3_79492374 (23)](https://user-images.githubusercontent.com/33584/94737700-2423d980-0323-11eb-8e33-19297c78de2b.png)

When exported to SVG or PNG, the output would have the following appearance, which is somewhat different from the browser view:

![epilogos hg19 15 S1 all chr3_69756986-chr3_79492374-(1g)](https://user-images.githubusercontent.com/33584/94738346-22a6e100-0324-11eb-8f44-63e11bcb232d.png)

I added some code to fix this, as well as some additional track options to give more strand-specific control over the label appearance (e.g., to color forward- and reverse-stranded annotation label text and parent elements differently). Default color options are set so as to mimic to the current track appearance (within the browser). I updated the `README` to reflect these additions.